### PR TITLE
Force a memory collection when the free memory is "low"

### DIFF
--- a/qubes-miragevpn.sha256
+++ b/qubes-miragevpn.sha256
@@ -1,1 +1,1 @@
-c1916f5d930383ddfe445f231e28db6e268b92a93858c83570a3766392d21f00  ./dist/qubes-miragevpn.xen
+3aacc6cef8fabb4c121bcb1bd5270f93a4d69584563414b7fa10f307ea3f296c  ./dist/qubes-miragevpn.xen


### PR DESCRIPTION
This PR is inspired by qubes-mirage-firewall. For each incoming and outgoing packets, it tests the free memory available, and if "low" (here <=40% of the total memory) it triggers a garbage collection.
Unlike qubes-mirage-firewall, there is nothing after to the garbage collection to get more memory.
In the dom0 logs, you can see that even a continuous ping decreases the free memory (from my point of view because of some cstructs in xenstore/etc.) :
```
[2024-06-24 08:29:10] 2024-06-24T06:29:10-00:00: [INFO] [application] Memory usage: free 10106432 / 24604672
[2024-06-24 08:29:20] 2024-06-24T06:29:20-00:00: [INFO] [application] Memory usage: free 10003184 / 24604672
[2024-06-24 08:29:30] 2024-06-24T06:29:30-00:00: [INFO] [application] Memory usage: free 9887840 / 24604672
[2024-06-24 08:29:40] 2024-06-24T06:29:40-00:00: [INFO] [application] Memory usage: free 13617776 / 24604672
[2024-06-24 08:29:50] 2024-06-24T06:29:50-00:00: [INFO] [application] Memory usage: free 13501536 / 24604672
...
[2024-06-24 08:34:10] 2024-06-24T06:34:10-00:00: [INFO] [application] Memory usage: free 10138656 / 24604672
[2024-06-24 08:34:20] 2024-06-24T06:34:20-00:00: [INFO] [application] Memory usage: free 10022704 / 24604672
[2024-06-24 08:34:30] 2024-06-24T06:34:30-00:00: [INFO] [application] Memory usage: free 9906336 / 24604672
[2024-06-24 08:34:40] 2024-06-24T06:34:40-00:00: [INFO] [application] Memory usage: free 13642208 / 24604672
[2024-06-24 08:34:50] 2024-06-24T06:34:50-00:00: [INFO] [application] Memory usage: free 13526288 / 24604672
```
The collection was able to get nearly 4MB of memory, and the second collection got the same amount a few minutes later.
To me, this will help to keep the amount of memory requested from Qubes by the unikernel as low as possible (the idea is that Linux is able to run with 400MB memory for network functions, and keeping unikernels an order of magnitude lower is good :) ).