### PR TITLE
Update to recent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,20 @@
 # It will probably still work on newer images, though, unless an update
 # changes some compiler optimisations (unlikely).
 # bookworm-slim taken from https://hub.docker.com/_/debian/tags?page=1&name=bookworm-slim
-FROM debian@sha256:3d5df92588469a4c503adbead0e4129ef3f88e223954011c2169073897547cac
+FROM debian@sha256:d365f4920711a9074c4bcd178e8f457ee59250426441ab2a5f8106ed8fe948eb
 # install remove default packages repository
 RUN rm /etc/apt/sources.list.d/debian.sources
 # and set the package source to a specific release too
 # taken from https://snapshot.debian.org/archive/debian
-RUN printf "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20240419T024211Z bookworm main\n" > /etc/apt/sources.list
+RUN printf "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20250103T213531Z bookworm main\n" > /etc/apt/sources.list
 # taken from https://snapshot.debian.org/archive/debian-security/
-RUN printf "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20240419T111010Z bookworm-security main\n" >> /etc/apt/sources.list
+RUN printf "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20250101T021323Z bookworm-security main\n" >> /etc/apt/sources.list
 
 RUN apt update && apt install --no-install-recommends --no-install-suggests -y wget ca-certificates git patch unzip bzip2 xz-utils make gcc g++ libc-dev
-RUN wget -O /usr/bin/opam https://github.com/ocaml/opam/releases/download/2.1.6/opam-2.1.6-i686-linux && chmod 755 /usr/bin/opam
+RUN wget -O /usr/bin/opam https://github.com/ocaml/opam/releases/download/2.3.0/opam-2.3.0-i686-linux && chmod 755 /usr/bin/opam
 # taken from https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
 RUN test `sha512sum /usr/bin/opam | cut -d' ' -f1` = \
-"2b308e7a848252d831a1e046b70156cd901e8a5d95405fc03244fc69ce08222675871d3bcc35352b4448f15787f68a16491c574a6f9d5d8c9bcab81eb6d71ef8" || exit
+"4c0e8771889a36bad4d5f964e2e662d5b611e6f112777d3d4eea3eea919d109cd17826beba38e6cfa1ad9553a0a989d9268f911ea5485968da04b1e08efc7de2" || exit
 
 ENV OPAMROOT=/tmp
 ENV OPAMCONFIRMLEVEL=unsafe-yes
@@ -23,14 +23,14 @@ ENV OPAMCONFIRMLEVEL=unsafe-yes
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
 # taken from https://github.com/ocaml/opam-repository
-RUN opam init --disable-sandboxing -a --bare https://github.com/ocaml/opam-repository.git#3bcb45c36ed254e850b498bff678e3e5848b23e1
+RUN opam init --disable-sandboxing -a --bare https://github.com/ocaml/opam-repository.git#306c328a5d8550ae58f29b3609c6f7a073c219ab
 RUN opam switch create myswitch 4.14.2
 RUN opam exec -- opam install -y mirage opam-monorepo ocaml-solo5
-RUN opam pin add -yn https://github.com/robur-coop/miragevpn.git#fe78f5067cb71d435c2dade2bfaac537b2a2e745
+RUN opam pin add -yn https://github.com/robur-coop/miragevpn.git#3e705ec00c2c482c49360fdda046a36da9361f03
 RUN mkdir /tmp/orb-build
 ADD config.ml /tmp/orb-build/config.ml
 WORKDIR /tmp/orb-build
 CMD opam exec -- sh -exc 'mirage configure -t xen --extra-repos=\
-opam-overlays:https://github.com/dune-universe/opam-overlays.git#4e75ee36715b27550d5bdb87686bb4ae4c9e89c4,\
+opam-overlays:https://github.com/dune-universe/opam-overlays.git#f2bec38beca4aea9e481f2fd3ee319c519124649,\
 mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git#797cb363df3ff763c43c8fbec5cd44de2878757e \
 && make depend && make build'

--- a/config.ml
+++ b/config.ml
@@ -8,8 +8,7 @@ let ethernet = ethif default_network
 let arp = arp ethernet
 let ipv4 = ipv4_qubes default_qubesdb ethernet arp
 let ipv6 = create_ipv6 default_network ethernet
-let i4i6 = create_ipv4v6 ipv4 ipv6
-let stack = direct_stackv4v6 ~tcp:(direct_tcp i4i6) default_network ethernet arp ipv4 ipv6
+let stack = direct_stackv4v6 default_network ethernet arp ipv4 ipv6
 
 let main =
   main

--- a/config.ml
+++ b/config.ml
@@ -21,7 +21,7 @@ let main =
         package "vchan" ~min:"4.0.2";
         package "shared-memory-ring" ~min:"3.0.0";
         package "mirage-net-xen" ~min:"2.1.3";
-        package "mirage-qubes" ~min:"0.9.1";
+        package "mirage-qubes" ~min:"0.11.0";
         package "mirage-xen" ~min:"8.0.0";
         package "ipaddr";
         package "ethernet" ~min:"3.0.0";

--- a/config.ml
+++ b/config.ml
@@ -1,21 +1,18 @@
-(* mirage >= 4.6.0 & < 4.7.0 *)
+(* mirage >= 4.8.1 & < 4.9.0 *)
 open Mirage
 
 (* xenstore id 51712 is the root volume *)
 let block = block_of_xenstore_id "51712"
-let config = tar_kv_ro block
+let disk = tar_kv_ro block
 let ethernet = ethif default_network
 let arp = arp ethernet
 let ipv4 = ipv4_qubes default_qubesdb ethernet arp
 let ipv6 = create_ipv6 default_network ethernet
-let ipv4_only = Runtime_arg.ipv4_only ~group:"sys-net" ()
-let ipv6_only = Runtime_arg.ipv4_only ~group:"sys-net" ()
-let stack = direct_stackv4v6 ~ipv4_only ~ipv6_only default_network ethernet arp ipv4 ipv6
-
-let config_key = runtime_arg ~pos:__POS__ "Unikernel.config_key"
+let i4i6 = create_ipv4v6 ipv4 ipv6
+let stack = direct_stackv4v6 ~tcp:(direct_tcp i4i6) default_network ethernet arp ipv4 ipv6
 
 let main =
-  main ~runtime_args:[ config_key ]
+  main
     ~packages:
       [
         package "vchan" ~min:"4.0.2";
@@ -39,5 +36,5 @@ let () =
       $ default_time
       $ default_qubesdb
       $ stack
-      $ config;
+      $ disk;
     ]

--- a/qubes-miragevpn.sha256
+++ b/qubes-miragevpn.sha256
@@ -1,1 +1,1 @@
-90176d104e52f51f69c8326a045a37a77916a2c0f914e50c837773afab7a9f37  ./dist/qubes-miragevpn.xen
+eef52a2d7e54f4dea40319b206eec8955476498e4300f43376a3e08ded3b521d  ./dist/qubes-miragevpn.xen


### PR DESCRIPTION
Dear the Robur team,
This PR wants to keep the unikernel up to date with recent changes (mirage 4.8, qubes-mirage). I've omitted Ocaml5 in the toolchain update, but I can add it while at it if you want.
The unikernel compiles and runs fine, the only downside is that I currently don't have a testing openvpn server, so I can't go further right now (but I'll try to setup one in a near future).
Best.