### PR TITLE
Update to Mirage 4.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,14 @@ ENV OPAMCONFIRMLEVEL=unsafe-yes
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
 # taken from https://github.com/ocaml/opam-repository
-RUN opam init --disable-sandboxing -a --bare https://github.com/ocaml/opam-repository.git#306c328a5d8550ae58f29b3609c6f7a073c219ab
+RUN opam init --disable-sandboxing -a --bare https://github.com/ocaml/opam-repository.git#70ed6dc3809eac914120062fdc7a82492f5c3ef9
 RUN opam switch create myswitch 4.14.2
 RUN opam exec -- opam install -y mirage opam-monorepo ocaml-solo5
-RUN opam pin add -yn https://github.com/robur-coop/miragevpn.git#3e705ec00c2c482c49360fdda046a36da9361f03
+RUN opam pin add -yn https://github.com/robur-coop/miragevpn.git#440768ae2fefc9da57e4a9f15bcbe6d217550d6c
 RUN mkdir /tmp/orb-build
 ADD config.ml /tmp/orb-build/config.ml
 WORKDIR /tmp/orb-build
 CMD opam exec -- sh -exc 'mirage configure -t xen --extra-repos=\
-opam-overlays:https://github.com/dune-universe/opam-overlays.git#f2bec38beca4aea9e481f2fd3ee319c519124649,\
+opam-overlays:https://github.com/dune-universe/opam-overlays.git#e031bb64e33bf93be963e9a38b28962e6e14381f,\
 mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git#797cb363df3ff763c43c8fbec5cd44de2878757e \
 && make depend && make build'

--- a/config.ml
+++ b/config.ml
@@ -1,4 +1,4 @@
-(* mirage >= 4.8.1 & < 4.9.0 *)
+(* mirage >= 4.9.0 & < 4.10.0 *)
 open Mirage
 
 (* xenstore id 51712 is the root volume *)
@@ -26,13 +26,12 @@ let main =
         package "mirage-nat" ~min:"3.0.0";
       ]
     "Unikernel.Main"
-    (random @-> mclock @-> pclock @-> time @-> qubesdb @-> stackv4v6 @-> kv_ro @-> job)
+    (qubesdb @-> stackv4v6 @-> kv_ro @-> job)
 
 let () =
   register "qubes-miragevpn"
     [
-      main $ default_random $ default_monotonic_clock $ default_posix_clock
-      $ default_time
+      main
       $ default_qubesdb
       $ stack
       $ disk;

--- a/qubes-miragevpn.sha256
+++ b/qubes-miragevpn.sha256
@@ -1,1 +1,1 @@
-eef52a2d7e54f4dea40319b206eec8955476498e4300f43376a3e08ded3b521d  ./dist/qubes-miragevpn.xen
+ac58937145d12dae425dbb9f7dca262917021b29edfce32cb116c1c0b8dcc3bf  ./dist/qubes-miragevpn.xen

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -281,7 +281,7 @@ struct
         let string_of_file _ = Error (`Msg "Impossible to load extra files") in
         match Miragevpn.Config.parse_client ~string_of_file contents with
         | Ok cfg -> Lwt.return cfg
-        | Error _ -> Fmt.failwith "Invalid OpenVPN configuration")
+        | Error (`Msg m) -> Fmt.failwith "Invalid OpenVPN configuration %s" m)
 
   let start qubesDB vif0 disk =
     Logs.debug (fun m -> m "Start the unikernel");

--- a/vif.ml
+++ b/vif.ml
@@ -9,8 +9,7 @@ module Netbackend = Backend.Make (Xenstore.Make (Xen_os.Xs))
                <-[client_ethernetn]-> [clientN]
 *)
 module Client_ethernet = Ethernet.Make (Netbackend)
-module Underlying_arp = Arp.Make (Client_ethernet) (Xen_os.Time)
-module R = Mirage_crypto_rng_mirage.Make(Xen_os.Time)(Mclock)
+module Underlying_arp = Arp.Make (Client_ethernet)
 
 module Client_arp = struct
   type t =
@@ -40,7 +39,7 @@ module Client_arp = struct
     then Lwt.return_ok t.your_mac else Lwt.return_ok t.my_mac
 end
 
-module Client_ip = Static_ipv4.Make(R)(Mclock)(Client_ethernet)(Client_arp)
+module Client_ip = Static_ipv4.Make(Client_ethernet)(Client_arp)
 
 type t =
   { ipaddr : Ipaddr.V4.t * Ipaddr.V4.t

--- a/vif.mli
+++ b/vif.mli
@@ -1,8 +1,7 @@
 module Netbackend : module type of Backend.Make (Xenstore.Make (Xen_os.Xs))
 module Client_ethernet : module type of Ethernet.Make (Netbackend)
-module R : module type of Mirage_crypto_rng_mirage.Make(Xen_os.Time)(Mclock)
 module Client_arp : Arp.S
-module Client_ip : module type of Static_ipv4.Make (R) (Mclock) (Client_ethernet) (Client_arp)
+module Client_ip : module type of Static_ipv4.Make (Client_ethernet) (Client_arp)
 
 type t = {
   ipaddr : Ipaddr.V4.t * Ipaddr.V4.t;


### PR DESCRIPTION
Dear developpers,
This PR update to recent mirage without functors for random/*time/sleep. It also updates the opam ecosystem and the mriagevpn pin. I also took the liberty to add the error message when the config file parsing fails (but feel free to ask that in another PR :) ).
While testing against a new openvpn server I do not observe anymore any AEAD crash of the tunnel. So \o/
Maybe the "no more crash" is due to my configuration file, so I'll continue testing.
Best.