### PR TITLE
Dns redirect

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,14 +19,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: ./build-with.sh docker
 
       - run: sh -exc 'if [ "$(sha256sum ./dist/qubes-miragevpn.xen)" = "$(cat ./qubes-miragevpn.sha256)" ]; then echo "SHA256 MATCHES"; else exit 42; fi'
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qubes-miragevpn.xen
           path: dist/qubes-miragevpn.xen

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -19,14 +19,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: ./build-with.sh podman
 
       - run: sh -exc 'if [ "$(sha256sum ./dist/qubes-miragevpn.xen)" = "$(cat ./qubes-miragevpn.sha256)" ]; then echo "SHA256 MATCHES"; else exit 42; fi'
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qubes-miragevpn.xen
           path: dist/qubes-miragevpn.xen

--- a/qubes-miragevpn.sha256
+++ b/qubes-miragevpn.sha256
@@ -1,1 +1,1 @@
-1e88db8aa3a6fc3a2d92ac62db10e1264726fa317613bd7541787da4cd55b894  ./dist/qubes-miragevpn.xen
+6277142f106f139db020dc085b59a979bc521ca051c10555b0e161ad618bd2af  ./dist/qubes-miragevpn.xen

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -103,7 +103,7 @@ struct
         | None -> Logs.warn (fun m -> m "%a does not exist as a client" Ipaddr.V4.pp ipaddr); Lwt.return_unit
   end
 
-  let compare a b = Ipaddr.V4.compare a b = 0
+  let equal_ipv4 a b = Ipaddr.V4.compare a b = 0
 
   let add_vif ~finalisers t ({ Dao.Client_vif.domid; device_id } as client_vif)
       ipaddr () =
@@ -115,8 +115,8 @@ struct
     let* vif = Vif.make backend client_vif ~gateway ipaddr in
     let* () = Clients.add_client t.clients vif in
     let should_be_routed hdr =
-      compare ipaddr hdr.Ipv4_packet.src
-      && not (compare ipaddr hdr.Ipv4_packet.dst) in
+      equal_ipv4 ipaddr hdr.Ipv4_packet.src
+      && not (equal_ipv4 ipaddr hdr.Ipv4_packet.dst) in
     Finaliser.add
       ~finaliser:(fun () -> Clients.rem_client t.clients vif)
       finalisers;
@@ -272,7 +272,7 @@ struct
       let (`IPv4 (hdr, _payload)) = packet in
       let (dns0, dns1, resolver) = t.dns in
       let mode = match hdr.Ipv4_packet.dst with
-      | ip when compare dns0 ip || compare dns1 ip -> `Redirect resolver
+      | ip when equal_ipv4 dns0 ip || equal_ipv4 dns1 ip -> `Redirect resolver
       | _ -> `NAT
       in
       begin match Mirage_nat_lru.add t.table packet (O.get_ip t.ovpn)


### PR DESCRIPTION
Dear developers,
For this PR I make the assumption that each client AppVM has, either the same DNS configuration as the unikernel (and the unikernel will redirect packets with those addresses as destination to a command specified address), or the AppVM has its own DNS resolver address and that address is accessible within the tunnel.
The first situation is the default setting, and users from the second situation will probably aware of their non-usual setup.
With this PR every packets that target default Qubes DNS addresses are redirected in the tunnel.
I'm open to any modification needed :)
As a side note, GH actions are disabled :(
Best.